### PR TITLE
Empty stdin shouldn't pause execution

### DIFF
--- a/bls-runtime/src/config.rs
+++ b/bls-runtime/src/config.rs
@@ -390,4 +390,36 @@ mod test {
         assert_eq!(config.0.get_limited_memory(), Some(30));
         assert_eq!(config.0.get_limited_fuel(), Some(200000000));
     }
+
+    #[test]
+    fn test_stdin_from_json() {
+        let bls_config = CliConfig::from_json_string(
+            r#"{
+                "fs_root_path": "/", 
+                "drivers_root_path": "/drivers", 
+                "runtime_logger": "runtime.log", 
+                "limited_fuel": 200000000,
+                "limited_memory": 30,
+                "debug_info": false,
+                "entry": "lib.wasm",
+                "permissions": []
+            }"#.to_string()
+        ).unwrap().0;
+        assert_eq!(bls_config.stdin_ref(), "");
+
+        let bls_config = CliConfig::from_json_string(
+            r#"{
+                "stdin": "test",
+                "fs_root_path": "/", 
+                "drivers_root_path": "/drivers", 
+                "runtime_logger": "runtime.log", 
+                "limited_fuel": 200000000,
+                "limited_memory": 30,
+                "debug_info": false,
+                "entry": "lib.wasm",
+                "permissions": []
+            }"#.to_string()
+        ).unwrap().0;
+        assert_eq!(bls_config.stdin_ref(), "test");
+    }
 }

--- a/bls-runtime/src/config.rs
+++ b/bls-runtime/src/config.rs
@@ -186,8 +186,8 @@ impl CliConfig {
         bc.set_run_time(run_time);
         version.map(|v| bc.set_version(v.into()));
 
-        if stdin.is_some() {
-            bc.stdin(stdin.unwrap().to_string());
+        if let Some(stdin) = stdin {
+            bc.stdin(stdin.to_string());
         }
         Ok(CliConfig(bc))
     }

--- a/bls-runtime/src/main.rs
+++ b/bls-runtime/src/main.rs
@@ -16,7 +16,7 @@ use config::load_cli_config_extract_from_car;
 use v86::V86Lib;
 use v86config::load_v86conf_extract_from_car;
 use std::{
-    io::{self, Read}, 
+    io::Read, 
     path::PathBuf, 
     time::Duration, 
 };
@@ -144,14 +144,6 @@ fn wasm_runtime(mut cfg: CliConfig, cli_command_opts: CliCommandOpts) -> CLIExit
         return err;
     }
 
-    let mut std_buffer = String::new();
-    if cfg.0.stdin_ref().is_empty() {
-        if let Err(err) = io::stdin().read_line(&mut std_buffer) {
-            eprintln!("failed to read from stdin: {}", err);
-            return CLIExitCode::UnknownError("failed to read from stdin".into());
-        }
-        cfg.0.stdin(std_buffer);
-    }
     let run_time = cfg.0.run_time();
     cli_command_opts.into_config(&mut cfg);
     let async_runtime = match Builder::new_current_thread()


### PR DESCRIPTION
## Context
Addresses: https://linear.app/blockless/issue/ENG-964/empty-stdin-shouldnt-pause-execution

---

The runtime execution pauses (to wait for stdin) - if no stdin is provided when running the CLI.
I.e. this would pause the runtime for stdin:
```sh
cargo run -- ./test.wasm
```
Hence the runtime must be run (currently like so):
```sh
echo "" | cargo run -- ./test.wasm
```

### Fix
This PR fixes the behaviour above, by defaulting stdin to empty string (if not provided in runtime config file); hence `cargo run -- ./test.wasm` will not pause for execution anymore.