### PR TITLE
POC host function impl for BLS extensions

### DIFF
--- a/blockless/Cargo.toml
+++ b/blockless/Cargo.toml
@@ -19,6 +19,7 @@ log = {workspace = true}
 lazy_static = {workspace = true}
 json = "0.12"
 tokio = {version = "1", features = ["sync"]}
+serde_json = "1.0.105"
 
 [dev-dependencies]
 tempdir = {workspace = true}

--- a/crates/blockless-drivers/Cargo.toml
+++ b/crates/blockless-drivers/Cargo.toml
@@ -33,6 +33,7 @@ rust-s3 = "0.32.0"
 futures-core = "0.3.25"
 futures-util = "0.3.25"
 md5 = "0.7.0"
+serde_json = "1.0.105"
 
 [dependencies.rusqlite]
 version = "0.28"


### PR DESCRIPTION
## Context
We want to standardize approach and SDK's to use memory sharing approach to share data between host and guest wasm module(s).

This PR implements a POC of how that can be achieved.

The host module can be called like so - for `http_req` module call as an example:
```json
{
  "module":"blockless::http_req",
  "params": {
    "url": "https://jsonplaceholder.typicode.com/todos/1",
    "opts": {
      "method":"GET",
      "connectTimeout":30,
      "readTimeout":10,
      "headers":"{}",
      "body":null
    }
  }
}
```

Example SDK code (which can be cleaned up):
```rust
#[link(wasm_import_module = "blockless")]
extern "C" {
    #[link_name = "module"]
    fn module_call(ptr: u32, len: u32, buf: *mut u8, blen: u32) -> u32;
}

pub fn module_call(url: &str, opts: &HttpOptions) {
    let opts = opts.dump();
    unsafe {
        let params = std::format!(
            "{{\"module\":\"blockless::http_req\", \"params\": {{\"url\": \"{}\", \"opts\": {}}}}}",
            url.to_string(),
            opts
        );
        println!("params: {}", params);
        let m_ptr = params.as_ptr();
        let mut result = [0u8; 256]; //  TODO: increase this
        println!("from module a send the to {}", params);
        let exit_code = module_call(
            m_ptr as u32,
            params.len() as u32,
            result.as_mut_ptr(),
            result.len() as u32,
        );
        println!("exit_code: {}", exit_code);
        // println!("result: {}", result);
        let str = std::str::from_utf8(&result).unwrap();
        if exit_code > 0 {
            println!("error blockless module call: {str}")
        } else {
            println!("result from blockless module call:\n{str}")
        }
    }
    println!("finish.");
}

use blockless_sdk::*;

fn main() {
    let opts = HttpOptions::new("GET", 30, 10);
    let http = module_call("https://jsonplaceholder.typicode.com/todos/1", &opts);
    println!("{:?}", http);
}
```

^ compile the WASM above (`cargo build --target wasm32-wasi`)

Run the compile WASM in runtime (with http permissions):
```sh
cargo run -- exam1.wasm --permission "https://jsonplaceholder.typicode.com/todos/1"
```

Output:
```
...
fd: 1; code: 200
exit_code: 0
result from blockless module call:
{
  "userId": 1,
  "id": 1,
  "title": "delectus aut autem",
  "completed": false
}
finish.
()
```
 