### PR TITLE
Override manifest permissions only if explicitly provided in CLI

### DIFF
--- a/bls-runtime/src/cli_clap.rs
+++ b/bls-runtime/src/cli_clap.rs
@@ -167,7 +167,9 @@ impl CliCommandOpts {
         conf.0.limited_fuel(self.limited_fuel);
         conf.0.set_run_time(self.run_time);
         conf.0.set_stdin_args(self.args);
-        conf.0.set_permisions(self.permissions);
+        if self.permissions.len() > 0 {
+            conf.0.set_permisions(self.permissions);
+        }
         conf.0.set_envs(self.envs);
         conf.0.set_drivers_root_path(self.drivers_root_path);
         let mut modules = self.modules;


### PR DESCRIPTION
## Context
The permissions provided by a `manifest.json` file are always overriden by CLI permissions - even though they may not be explicitly provided in the CLI command.
This causes the permissions in the `manifest.json` file to be ignored.

This PR addresses the issue by only overriding the permissions provided by the `manifest.json` file if they are explicitly provided in the CLI command.