### PR TITLE
Added short about and version flag to runtime

### DIFF
--- a/bls-runtime/Cargo.toml
+++ b/bls-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls-runtime"
-version = "0.1.0"
+version = "0.3.2"
 authors = ["Join.G"]
 description = "command line example"
 keywords = ["webassembly", "wasm"]

--- a/bls-runtime/src/cli_clap.rs
+++ b/bls-runtime/src/cli_clap.rs
@@ -92,7 +92,11 @@ pub enum RuntimeType {
     Wasm,
 }
 
+/// The latest version from Cargo.toml
+pub(crate) const SHORT_VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
+
 #[derive(Parser, Debug)]
+#[command(author, version = SHORT_VERSION, long_version = SHORT_VERSION, about = "Blockless WebAssembly Runtime", long_about = None)]
 pub(crate) struct CliCommandOpts {
     #[clap(long = "v86", value_name = "V86", required = false, help = V86_HELP )]
     v86: bool,
@@ -204,7 +208,7 @@ mod test {
 
     #[test]
     fn test_cli_command_v86() {
-        let cli = CliCommandOpts::try_parse_from(["cli", "test", "--v86"]).unwrap();;
+        let cli = CliCommandOpts::try_parse_from(["cli", "test", "--v86"]).unwrap();
         assert_eq!(cli.v86, true);
     }
 


### PR DESCRIPTION
# Context
There is no straightforward way to identify the `bls-runtime` version. This PR adds support for that.
The CLI `version` is derived from the `Cargo.toml` in the `bls-runtime` dir/workspace.

From this point, any version updates should be reflected in the `bls-runtime/Cargo.toml` file.