### PR TITLE
Update runtime_release_win.yml

### DIFF
--- a/.github/workflows/runtime_release_win.yml
+++ b/.github/workflows/runtime_release_win.yml
@@ -22,6 +22,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Edit Toml
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: "bls-runtime/Cargo.toml"
+          key: "version"
+          value: "${{ steps.get_release.outputs.tag_name }}"
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -60,11 +71,6 @@ jobs:
           filename: ../../../blockless-runtime.${{ matrix.os }}.${{ matrix.arch }}.tar.gz
           directory: target/${{ matrix.target }}/release
           path: .
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.2.3
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: upload artifact
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
automatically bumps the version of the blockless-cli crate based on the release version of the tag