### PR TITLE
fix: the windows compile error issue.

### DIFF
--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,7 +22,7 @@ log = { workspace = true }
 rustix = {workspace = true}
 
 [target.'cfg(windows)'.dependencies]
-io-extras = "0.17.0"
+io-extras = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true


### PR DESCRIPTION
fix the windows build issue. The windows dependency used the older version of "io-extras".