### PR TITLE
Env file support to import environment variables

### DIFF
--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@1.80
         with:
           components: rustfmt
       - run: cargo fmt --all --check

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 **/*.rs.bk
 ._target
 *.log
+
+# Env files
+.env

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Blockless supports a variety of programming languages including:
 
 ## The example of configure file 
 
-```jsonc
+```json
 {
     "fs_root_path": "/Users/join/Downloads", 
     "drivers_root_path": "/Users/join/Downloads", 
@@ -70,8 +70,6 @@ Blockless supports a variety of programming languages including:
         ...
     }
 }
-
-
 ```
 
 - `fs_root_path`: The root file system path of the app. When the app is opened, it will use this file system as its "/".
@@ -113,7 +111,7 @@ The runtime requires an input from stdin and also accepts environment variables 
 $ "echo "FOO" | env THIS_IS_MY_VAR=FOO BLS_LIST_VARS=THIS_IS_MY_VAR ~/.bls/runtime/blockless-cli ./build/manifest.json"
 ```
 
-## Exit code
+## Exit codes
 
 |code|description|
 |----|-------------------|

--- a/bls-runtime/Cargo.toml
+++ b/bls-runtime/Cargo.toml
@@ -22,5 +22,5 @@ once_cell.workspace = true
 dotenvy = "0.15.7"
 env_logger = { workspace = true }
 
-[dependencies.env_logger]
-workspace = true
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/bls-runtime/Cargo.toml
+++ b/bls-runtime/Cargo.toml
@@ -19,6 +19,8 @@ url = { workspace = true }
 clap = { workspace = true, features = ["color", "suggestions", "derive"] }
 dlopen = { workspace = true }
 once_cell.workspace = true
+dotenvy = "0.15.7"
+env_logger = { workspace = true }
 
 [dependencies.env_logger]
 workspace = true

--- a/bls-runtime/src/cli_clap.rs
+++ b/bls-runtime/src/cli_clap.rs
@@ -356,11 +356,11 @@ impl CliCommandOpts {
 
 #[cfg(test)]
 mod test {
-
-    use blockless::BlocklessConfigVersion;
-
     #[allow(unused)]
     use super::*;
+    use blockless::BlocklessConfigVersion;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn test_cli_command_v86() {
@@ -384,6 +384,52 @@ mod test {
         assert_eq!(cli.envs.len(), 2);
         assert_eq!(cli.envs[0], ("a".to_string(), "1".to_string()));
         assert_eq!(cli.envs[1], ("b".to_string(), "2".to_string()));
+    }
+
+    #[test]
+    fn test_cli_command_env_file_loading_and_sorting() -> Result<()> {
+        // Create temp env file with variables including interpolation
+        let mut env_file = NamedTempFile::new()?;
+        writeln!(
+            env_file,
+            r#"COMMON_VAR=from_file
+ZOO_VAR=zebra
+BASE_URL=https://api.example.com
+SERVICE_URL=${{BASE_URL}}/v1"#
+        )?;
+
+        let cli = CliCommandOpts::try_parse_from([
+            "cli",
+            "test.wasm", // required input argument
+            "--env-file",
+            env_file.path().to_str().unwrap(),
+            "--env",
+            "COMMON_VAR=from_cli",
+            "--env",
+            "APP_VAR=test",
+        ])
+        .unwrap();
+
+        let envs = cli.load_environment_vars()?;
+
+        assert_eq!(
+            envs,
+            vec![
+                ("APP_VAR".to_string(), "test".to_string()),
+                (
+                    "BASE_URL".to_string(),
+                    "https://api.example.com".to_string()
+                ),
+                ("COMMON_VAR".to_string(), "from_cli".to_string()), // CLI value takes precedence
+                (
+                    "SERVICE_URL".to_string(),
+                    "https://api.example.com/v1".to_string()
+                ), // interpolated value
+                ("ZOO_VAR".to_string(), "zebra".to_string()),
+            ]
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/bls-runtime/src/cli_clap.rs
+++ b/bls-runtime/src/cli_clap.rs
@@ -11,6 +11,7 @@ use clap::{
 use std::{
     collections::HashMap,
     net::{IpAddr, SocketAddr, TcpListener, ToSocketAddrs},
+    path::{Path, PathBuf},
     str::FromStr,
 };
 use url::Url;
@@ -38,6 +39,8 @@ const ENTRY_HELP: &str = "the entry for wasm, default is _start";
 const LIMITED_FUEL_HELP: &str = "the limited fuel for runtime, default is infine";
 
 const ENVS_HELP: &str = "the app envs will pass into the app";
+
+const ENV_FILE_HELP: &str = "path to an environment file (.env) to load variables from";
 
 const OPTS_HELP: &str = "Optimization and tuning related options for wasm performance";
 
@@ -222,6 +225,9 @@ pub(crate) struct CliCommandOpts {
     #[clap(long = "env", value_name = "ENV=VAL", help = ENVS_HELP, number_of_values = 1, value_parser = parse_envs)]
     envs: Vec<(String, String)>,
 
+    #[clap(long = "env-file", value_name = "ENV_FILE", help = ENV_FILE_HELP)]
+    env_file: Option<PathBuf>,
+
     #[clap(long = "opt", short = 'O', value_name = "OPT=VAL,", help = OPTS_HELP,  value_parser = parse_opts)]
     opts: Option<OptimizeOpts>,
 
@@ -259,6 +265,8 @@ impl CliCommandOpts {
     }
 
     pub fn into_config(self, conf: &mut CliConfig) -> Result<()> {
+        let envs = self.load_environment_vars()?;
+
         conf.0.set_debug_info(self.debug_info);
         conf.0.set_fs_root_path(self.fs_root_path);
         conf.0.set_runtime_logger(self.runtime_logger);
@@ -268,6 +276,8 @@ impl CliCommandOpts {
         conf.0.set_stdin_args(self.args);
         conf.0.set_map_dirs(self.dirs);
         conf.0.set_feature_thread(self.feature_thread);
+
+        // Handle IO settings
         if let Some(stderr) = self.stderr {
             conf.0.stdio.stderr = stderr;
         }
@@ -280,7 +290,10 @@ impl CliCommandOpts {
         if self.permissions.len() > 0 {
             conf.0.set_permisions(self.permissions);
         }
-        conf.0.set_envs(self.envs);
+
+        // Handle environment variables
+        conf.0.set_envs(envs);
+
         conf.0.set_drivers_root_path(self.drivers_root_path);
         let mut modules = self.modules;
         let mut has_entry = false;
@@ -304,6 +317,40 @@ impl CliCommandOpts {
         }
         conf.0.tcp_listens = self.tcp_listens;
         Ok(())
+    }
+
+    /// Load and merge environment variables from both the environment file and explicit --env arguments.
+    /// Explicit environment variables take precedence over those from the file.
+    /// The environment variables are sorted by key.
+    fn load_environment_vars(&self) -> Result<Vec<(String, String)>> {
+        let mut final_envs = Vec::new();
+
+        // Load vars from env file if specified
+        if let Some(env_file) = &self.env_file {
+            let env_path = Path::new(env_file);
+            if env_path.exists() {
+                // Read variables from the env file
+                let file_vars = dotenvy::from_path_iter(env_path)?
+                    .filter_map(Result::ok)
+                    .collect::<Vec<(String, String)>>();
+                // Add all variables from the file
+                final_envs.extend(file_vars);
+            }
+        }
+
+        // Add explicit environment variables, overwriting any duplicates from the file
+        for env_var in &self.envs {
+            // Remove any existing variable with the same name
+            if let Some(index) = final_envs.iter().position(|(key, _)| key == &env_var.0) {
+                final_envs.remove(index);
+            }
+            final_envs.push(env_var.clone());
+        }
+
+        // Sort environment variables by key
+        final_envs.sort_by(|(a_key, _), (b_key, _)| a_key.cmp(b_key));
+
+        Ok(final_envs)
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.80.0"


### PR DESCRIPTION
# Context

- Defining multiple env vars requires passing them explicitly as CLI args to the runtime; which can be become very cumbersome - especially if there a lot of them
- This PR allows you to specify an env file - via the `env-file` arg to the runtime CLI
  - This will simply read/parse the keys/values in the file and set them as env vars in the runtime wasm context
  - The env file supports variable interpolation - i.e. env vars can be derived off other env vars within the file
  - Explicit env vars passed in the CLI take precedence over those in the env file
- This PR also includes a unit test for the env file support