### PR TITLE
Feature/socket fd

### DIFF
--- a/blockless/src/lib.rs
+++ b/blockless/src/lib.rs
@@ -144,7 +144,7 @@ impl BlocklessConfig2Preview1WasiBuilder for BlocklessConfig {
         }
         //set the tcp listener.
         for (l, fd) in b_conf.tcp_listens.iter() {
-            let fd = if let Some(fd) = fd  {
+            let fd = if let Some(fd) = fd {
                 if *fd < max_fd {
                     bail!("the invalid fd{fd} for listenfd.");
                 }

--- a/bls-runtime/src/cli_clap.rs
+++ b/bls-runtime/src/cli_clap.rs
@@ -9,10 +9,7 @@ use clap::{
     Arg, ArgMatches, Command, Parser,
 };
 use std::{
-    collections::HashMap,
-    net::{IpAddr, SocketAddr, TcpListener, ToSocketAddrs},
-    path::{Path, PathBuf},
-    str::FromStr,
+    collections::HashMap, net::{IpAddr, SocketAddr, TcpListener, ToSocketAddrs}, option, path::{Path, PathBuf}, str::FromStr
 };
 use url::Url;
 
@@ -61,6 +58,9 @@ const V86_HELP: &str =
 
 const THREAD_SUPPORT_HELP: &str =
     "the thread support flag when the flag setting the runtime will support multi-threads.";
+
+const SOCK_BASE_HELP: &str = 
+    "The socket base defines the base file descriptor (fd) for sockets, which WASI uses as the socket fd.";
 
 const TCP_LISTEN_HELP: &str = "grant access to the given TCP listen socket";
 
@@ -240,6 +240,9 @@ pub(crate) struct CliCommandOpts {
     #[clap(long = "tcplisten", help = TCP_LISTEN_HELP, value_parser = parse_listen)]
     tcp_listens: Vec<SocketAddr>,
 
+    #[clap(long = "sockbase", help = SOCK_BASE_HELP)]
+    sock_base: Option<u32>,
+
     #[clap(value_name = "ARGS", help = APP_ARGS_HELP)]
     args: Vec<String>,
 }
@@ -316,6 +319,7 @@ impl CliCommandOpts {
                 .set_version(blockless::BlocklessConfigVersion::Version1);
         }
         conf.0.tcp_listens = self.tcp_listens;
+        conf.0.sock_base = self.sock_base;
         Ok(())
     }
 

--- a/bls-runtime/src/cli_clap.rs
+++ b/bls-runtime/src/cli_clap.rs
@@ -9,7 +9,11 @@ use clap::{
     Arg, ArgMatches, Command, Parser,
 };
 use std::{
-    collections::HashMap, net::{IpAddr, SocketAddr, TcpListener, ToSocketAddrs}, option, path::{Path, PathBuf}, str::FromStr
+    collections::HashMap,
+    net::{IpAddr, SocketAddr, TcpListener, ToSocketAddrs},
+    option,
+    path::{Path, PathBuf},
+    str::FromStr,
 };
 use url::Url;
 

--- a/crates/wasi-common/src/blockless/config.rs
+++ b/crates/wasi-common/src/blockless/config.rs
@@ -389,6 +389,7 @@ pub struct BlocklessConfig {
     pub modules: Vec<BlocklessModule>,
     pub runtime_logger: Option<String>,
     pub extensions_path: Option<String>,
+    pub sock_base: Option<u32>,
     // the config version
     pub version: BlocklessConfigVersion,
     pub drivers_root_path: Option<String>,
@@ -413,6 +414,8 @@ impl BlocklessConfig {
             //vm instruction limit.
             limited_fuel: None,
             limited_time: None,
+            // define the base fd
+            sock_base: None,
             tcp_listens: Vec::new(),
             stdin_args: Vec::new(),
             //memory limit, 1 page = 64k.

--- a/crates/wasi-common/src/blockless/config.rs
+++ b/crates/wasi-common/src/blockless/config.rs
@@ -382,14 +382,13 @@ pub struct BlocklessConfig {
     pub drivers: Vec<DriverConfig>,
     pub store_limited: StoreLimited,
     pub envs: Vec<(String, String)>,
-    pub tcp_listens: Vec<SocketAddr>,
+    pub tcp_listens: Vec<(SocketAddr, Option<u32>)>,
     pub permisions: Vec<Permission>,
     pub dirs: Vec<(String, String)>,
     pub fs_root_path: Option<String>,
     pub modules: Vec<BlocklessModule>,
     pub runtime_logger: Option<String>,
     pub extensions_path: Option<String>,
-    pub sock_base: Option<u32>,
     // the config version
     pub version: BlocklessConfigVersion,
     pub drivers_root_path: Option<String>,
@@ -415,7 +414,6 @@ impl BlocklessConfig {
             limited_fuel: None,
             limited_time: None,
             // define the base fd
-            sock_base: None,
             tcp_listens: Vec::new(),
             stdin_args: Vec::new(),
             //memory limit, 1 page = 64k.


### PR DESCRIPTION
1. support listenfd with file descriptor for bls-runtime using the args --tcplisten=address:port::listenfd, e.g. --tcplisten=120.0.0.1:8080::10