### PR TITLE
support the compiled cache.

### DIFF
--- a/blockless/src/lib.rs
+++ b/blockless/src/lib.rs
@@ -254,6 +254,7 @@ impl BlocklessConfig2Preview1WasiBuilder for BlocklessConfig {
         if self.feature_thread() {
             conf.wasm_threads(true);
         }
+        conf.cache_config_load_default().unwrap();
         conf
     }
 


### PR DESCRIPTION
1. support the compiled cache, it's reduce the compilation time when the wasm file is large.